### PR TITLE
Add provision command and config merge process

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,9 @@
 
 ## Configuration
 
-It is possible to configure the host names for your local environment through the `composer.json` file. This should be done before running the setup steps below, otherwise you may need to edit the generated `chassis/config.local.yaml` file directly.
+It is possible to extend the default configuration for your local environment through the `composer.json` file. The values you can set correspond to those found in the Chassis documentation. In most cases you won't need to change anything here.
+
+The following example adds some custom hosts and an extension:
 
 ```json
 {
@@ -19,6 +21,9 @@ It is possible to configure the host names for your local environment through th
 						"project.local",
 						"subdomain.project.local",
 						"alt-project.local"
+					],
+					"extensions": [
+						"xdebug"
 					]
 				}
 			}
@@ -53,6 +58,7 @@ A number of convenience commands are available:
 * `composer chassis status` - Displays the status of the virtual machine.
 * `composer chassis secure` - Installs the generated SSL certificate to your trusted certificate store.
 * `composer chassis shell` - Logs in to the virtual machine.
+* `composer chassis provision` - Updates the `config.local.yaml` file and re-provisions the machine.
 
 Under the hood, the Local Chassis environment is powered by [Chassis](http://chassis.io/) and [Vagrant](https://www.vagrantup.com/).
 
@@ -70,7 +76,9 @@ We recommend the following common development tools:
 * [phpdbg](https://github.com/Chassis/phpdbg) - Installs phpdbg for interactive command-line debugging
 * [Mailhog](https://github.com/Chassis/MailHog) - Captures outbound email from Altis and provides a fake inbox
 
-Consult the [Chassis documentation](http://docs.chassis.io/en/latest/extend/) for information about installing additional extensions.
+You can add extra extensions by adding them to the project's `composer.json` config as shown in the [configuration section of this page](#Configuration) and running `composer chassis provision`.
+
+Consult the [Chassis documentation](http://docs.chassis.io/en/latest/extend/) for further information about installing additional extensions.
 
 
 ## Using HTTPS locally

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -237,6 +237,10 @@ class Command extends BaseCommand {
 
 	/**
 	 * Command to update the config.local.yaml file and re-provision.
+	 *
+	 * @param InputInterface $input Command input object.
+	 * @param OutputInterface $output Command output object.
+	 * @return int
 	 */
 	protected function provision( InputInterface $input, OutputInterface $output ) {
 		$success = $this->write_config_file();
@@ -346,7 +350,7 @@ class Command extends BaseCommand {
 					$merged[ $key ] = $value;
 				}
 			} else {
-				// Merge numerically keyed arrays directly and remove empty/dupliocate items.
+				// Merge numerically keyed arrays directly and remove empty/duplicate items.
 				$merged = array_merge( $merged, (array) $overrides );
 				$merged = array_filter( $merged );
 				$merged = array_unique( $merged );

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -39,8 +39,7 @@ class Command extends BaseCommand {
 	 * @return string Path to the Chassis directory
 	 */
 	protected function get_chassis_dir() {
-		$root = dirname( $this->getComposer()->getConfig()->getConfigSource()->getName() );
-		return $root . DIRECTORY_SEPARATOR . CHASSIS_DIR;
+		return $this->get_root_dir() . DIRECTORY_SEPARATOR . CHASSIS_DIR;
 	}
 
 	/**
@@ -70,6 +69,9 @@ class Command extends BaseCommand {
 
 			case 'shell':
 				return $this->shell( $input, $output );
+
+			case 'provision':
+				return $this->provision( $input, $output );
 
 			default:
 				throw new CommandNotFoundException( sprintf( 'Subcommand "%s" is not defined.', $command ) );
@@ -106,33 +108,8 @@ class Command extends BaseCommand {
 			return $status;
 		}
 
-		// Get project host names from config.
-		$hosts = $this->get_project_hosts();
-
-		// Write the default config.
-		$config = [
-			'machine_name' => $hosts[0],
-			'php' => '7.2',
-			'paths' => [
-				'base' => '..',
-				'wp' => 'wordpress',
-				'content' => 'content',
-			],
-			'hosts' => $hosts,
-			'multisite' => true,
-			'extensions' => [
-				'humanmade/platform_chassis_extension',
-			],
-			'elasticsearch' => [
-				'plugins' => [
-					'analysis-icu',
-					'ingest-attachment',
-				],
-			],
-		];
-		$yaml = Yaml::dump( $config );
-		// @codingStandardsIgnoreLine
-		$success = file_put_contents( $chassis_dir . DIRECTORY_SEPARATOR . 'config.local.yaml', $yaml );
+		// Create the default config file.
+		$success = $this->write_config_file();
 		if ( ! $success ) {
 			$output->writeln( '<error>Could not write Chassis config</error>' );
 			return 1;
@@ -259,19 +236,24 @@ class Command extends BaseCommand {
 	}
 
 	/**
+	 * Command to update the config.local.yaml file and re-provision.
+	 */
+	protected function provision( InputInterface $input, OutputInterface $output ) {
+		$success = $this->write_config_file();
+		if ( ! $success ) {
+			$output->writeln( '<error>Could not write Chassis config</error>' );
+			return 1;
+		}
+		return $this->run_command( 'vagrant provision' );
+	}
+
+	/**
 	 * Get the name of the project host names from the local config.
 	 *
 	 * @return array
 	 */
 	protected function get_project_hosts() : array {
-
-		$composer_json = json_decode( file_get_contents( getcwd() . '/composer.json' ), true );
-
-		if ( isset( $composer_json['extra']['altis']['modules']['local-chassis']['hosts'] ) ) {
-			$hosts = (array) $composer_json['extra']['altis']['modules']['local-chassis']['hosts'];
-		} else {
-			$hosts = [ basename( getcwd() ) ];
-		}
+		$hosts = (array) ( $this->get_config()['hosts'] ?? [ basename( $this->get_root_dir() ) ] );
 
 		$hosts = array_map( function ( $host ) {
 			// Ensure .local suffixes.
@@ -285,4 +267,102 @@ class Command extends BaseCommand {
 
 		return $hosts;
 	}
+
+	/**
+	 * Get the root directory path for the project.
+	 *
+	 * @return string
+	 */
+	protected function get_root_dir() : string {
+		return dirname( $this->getComposer()->getConfig()->getConfigSource()->getName() );
+	}
+
+	/**
+	 * Get the Local Chassis config from composer.json.
+	 *
+	 * @return array
+	 */
+	protected function get_config() : array {
+		// @codingStandardsIgnoreLine
+		$json = file_get_contents( $this->get_root_dir() . DIRECTORY_SEPARATOR . 'composer.json' );
+		$composer_json = json_decode( $json, true );
+
+		return (array) $composer_json['extra']['altis']['modules']['local-chassis'] ?? [];
+	}
+
+	/**
+	 * Writes the config.local.yaml file with Altis customisations.
+	 *
+	 * @return bool Returns false if the file write fails.
+	 */
+	protected function write_config_file() : bool {
+		// Get project host names from config.
+		$hosts = $this->get_project_hosts();
+
+		// Write the default config.
+		$config = [
+			'machine_name' => $hosts[0],
+			'php' => '7.2',
+			'paths' => [
+				'base' => '..',
+				'wp' => 'wordpress',
+				'content' => 'content',
+			],
+			'hosts' => $hosts,
+			'multisite' => true,
+			'extensions' => [
+				'humanmade/platform_chassis_extension',
+			],
+			'elasticsearch' => [
+				'plugins' => [
+					'analysis-icu',
+					'ingest-attachment',
+				],
+			],
+		];
+
+		// Merge config from composer.json.
+		$overrides = $this->get_config();
+		$config = $this->merge_config( $config, $overrides );
+
+		// Remove the enabled setting.
+		unset( $config['enabled'] );
+
+		// Convert to YAML.
+		$yaml = Yaml::dump( $config );
+
+		// @codingStandardsIgnoreLine
+		return file_put_contents( $this->get_chassis_dir() . DIRECTORY_SEPARATOR . 'config.local.yaml', $yaml );
+	}
+
+	/**
+	 * Merges two configuration arrays together, overriding the first or adding
+	 * to it with items from the second.
+	 *
+	 * @param array $config The default config array.
+	 * @param array $overrides The config to merge in.
+	 * @return array
+	 */
+	protected function merge_config( array $config, array $overrides ) : array {
+		$merged = $config;
+		foreach ( $overrides as $key => $value ) {
+			if ( is_string( $key ) ) {
+				if ( is_array( $value ) ) {
+					// Recursively merge arrays.
+					$merged[ $key ] = $this->merge_config( $merged[ $key ], $value );
+				} else {
+					// Overwrite scalar values directly.
+					$merged[ $key ] = $value;
+				}
+			} else {
+				// Merge numerically keyed arrays directly and remove empty/dupliocate items.
+				$merged = array_merge( $merged, (array) $overrides );
+				$merged = array_filter( $merged );
+				$merged = array_unique( $merged );
+				break;
+			}
+		}
+		return $merged;
+	}
+
 }


### PR DESCRIPTION
This allows users to extend the generated config.local.yaml file via the composer.json configuration. It makes it easier to add extensions and override / modify extension configurations too such as giving elasticsearch more memory.

Fixes #42