### PR TITLE
Add exec command and support for PHPUnit

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ A number of convenience commands are available:
 * `composer chassis status` - Displays the status of the virtual machine.
 * `composer chassis secure` - Installs the generated SSL certificate to your trusted certificate store.
 * `composer chassis shell` - Logs in to the virtual machine.
+* `composer chassis exec -- <command>` - Run a command on the virtual machine.
 
 Under the hood, the Local Chassis environment is powered by [Chassis](http://chassis.io/) and [Vagrant](https://www.vagrantup.com/).
 

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -29,6 +29,10 @@ class Command extends BaseCommand {
 			InputArgument::REQUIRED,
 			'Subcommand to run'
 		);
+		$this->addArgument(
+			'options',
+			InputArgument::IS_ARRAY
+		);
 	}
 
 	/**
@@ -70,6 +74,9 @@ class Command extends BaseCommand {
 
 			case 'shell':
 				return $this->shell( $input, $output );
+
+			case 'exec':
+				return $this->exec( $input, $output );
 
 			default:
 				throw new CommandNotFoundException( sprintf( 'Subcommand "%s" is not defined.', $command ) );
@@ -256,6 +263,16 @@ class Command extends BaseCommand {
 	 */
 	protected function shell( InputInterface $input, OutputInterface $output ) {
 		return $this->run_command( 'vagrant ssh' );
+	}
+
+	/**
+	 * Command to pass a command in to the virtual machine.
+	 */
+	protected function exec( InputInterface $input, OutputInterface $output ) {
+		$command = implode( ' ', $input->getArgument( 'options' ) );
+		$command = escapeshellcmd( $command );
+
+		return $this->run_command( sprintf( 'vagrant ssh -c "cd /chassis && %s"', $command ) );
 	}
 
 	/**

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -247,9 +247,9 @@ class Command extends BaseCommand {
 	 */
 	protected function exec( InputInterface $input, OutputInterface $output ) {
 		$command = implode( ' ', $input->getArgument( 'options' ) );
-		$command = escapeshellcmd( $command );
+		$command = escapeshellarg( "cd /chassis && $command" );
 
-		return $this->run_command( sprintf( 'vagrant ssh -c "cd /chassis && %s"', $command ) );
+		return $this->run_command( sprintf( 'vagrant ssh -c %s', $command ) );
 	}
 
 	/**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -35,6 +35,9 @@ function set_file_path_map( array $map ) : array {
 	return $map;
 }
 
+/**
+ * Configure and bootstrap the Chassis environment.
+ */
 function load_chassis() {
 	if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
 		define( 'DB_NAME', 'wordpress' ); // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -7,6 +7,7 @@ namespace Altis\Local_Chassis;
  */
 function bootstrap() {
 	add_filter( 'qm/output/file_path_map', __NAMESPACE__ . '\\set_file_path_map', 1 );
+	load_chassis();
 }
 
 /**
@@ -32,4 +33,35 @@ function set_file_path_map( array $map ) : array {
 	}
 
 	return $map;
+}
+
+function load_chassis() {
+	if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
+		define( 'DB_NAME', 'wordpress' ); // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+		define( 'DB_USER', 'wordpress' ); // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+		define( 'DB_PASSWORD', 'vagrantpassword' );
+		define( 'DB_HOST', 'localhost' );
+
+		defined( 'ABSPATH' ) or define( 'ABSPATH', '/chassis/wordpress/' );
+		defined( 'WP_CONTENT_DIR' ) or define( 'WP_CONTENT_DIR', '/chassis/content' );
+	} else {
+		require_once '/vagrant/local-config-db.php';
+	}
+
+	require_once '/vagrant/local-config-extensions.php';
+
+	// When Chassis is configured with subdomains for hosts, it will attempt to load
+	// a file via /vagrant/local-config-extensions.php that will register a filter
+	// directly on the wp_filter global. This will break loading with Altis, because
+	// the plugin API is loaded very early. This will results in a $GLOBALS['wp_filter']
+	// that has already been "upgraded" to WP_Hook objects, so the direct below hooked
+	// added by Chassis will cause a fatal error.
+	//
+	// As a workaround, we remove the "direct" added hook via the PHP global, and just call
+	// add_action on the function that was registered.
+	if ( is_array( $GLOBALS['wp_filter']['muplugins_loaded'] ) && isset( $GLOBALS['wp_filter']['muplugins_loaded'][10]['chassis-hosts'] ) ) {
+		$function = $GLOBALS['wp_filter']['muplugins_loaded'][10]['chassis-hosts']['function'];
+		unset( $GLOBALS['wp_filter']['muplugins_loaded'] );
+		add_action( 'muplugins_loaded', $function );
+	}
 }

--- a/load.php
+++ b/load.php
@@ -5,39 +5,9 @@ namespace Altis\Local_Chassis;  // @codingStandardsIgnoreLine
 use function Altis\get_environment_architecture;
 use function Altis\register_module;
 
-// Load database configuration on Chassis installs.
-if ( file_exists( '/vagrant/local-config-extensions.php' ) ) {
-	 // @codingStandardsIgnoreStart
+// Set the architecture constant when on the VM.
+if ( file_exists( '/vagrant/local-config-db.php' ) ) {
 	define( 'HM_ENV_ARCHITECTURE', 'chassis' );
-	define( 'DB_NAME',     'wordpress' );
-	define( 'DB_USER',     'wordpress' );
-	define( 'DB_PASSWORD', 'vagrantpassword' );
-	define( 'DB_HOST',     'localhost' );
-
-	defined( 'ABSPATH' ) or define( 'ABSPATH', '/chassis/wordpress/' );
-	defined( 'WP_CONTENT_DIR' ) or define( 'WP_CONTENT_DIR', '/chassis/content' );
-
-	if ( empty( $_SERVER['HTTP_HOST'] ) ) {
-		$_SERVER['HTTP_HOST'] = 'altis.local';
-	}
-
-	require_once '/vagrant/local-config-extensions.php';
-	 // @codingStandardsIgnoreEnd
-
-	// When Chassis is configured with subdomains for hosts, it will attempt to load
-	// a file via /vagrant/local-config-extensions.php that will register a filter
-	// directly on the wp_filter global. This will break loading with Altis, because
-	// the plugin API is loaded very early. This will results in a $GLOBALS['wp_filter']
-	// that has already been "upgraded" to WP_Hook objects, so the direct below hooked
-	// added by Chassis will cause a fatal error.
-	//
-	// As a workaround, we remove the "direct" added hook via the PHP global, and just call
-	// add_action on the function that was registered.
-	if ( is_array( $GLOBALS['wp_filter']['muplugins_loaded'] ) && isset( $GLOBALS['wp_filter']['muplugins_loaded'][10]['chassis-hosts'] ) ) {
-		$function = $GLOBALS['wp_filter']['muplugins_loaded'][10]['chassis-hosts']['function'];
-		unset( $GLOBALS['wp_filter']['muplugins_loaded'] );
-		add_action( 'muplugins_loaded', $function );
-	}
 }
 
 add_action( 'altis.modules.init', function () {

--- a/load.php
+++ b/load.php
@@ -6,16 +6,20 @@ use function Altis\get_environment_architecture;
 use function Altis\register_module;
 
 // Load database configuration on Chassis installs.
-if ( file_exists( '/vagrant/local-config-db.php' ) ) {
-	$original_table_prefix = $table_prefix ?? 'wp_';
-
+if ( file_exists( '/vagrant/local-config-extensions.php' ) ) {
 	 // @codingStandardsIgnoreStart
 	define( 'HM_ENV_ARCHITECTURE', 'chassis' );
-	require_once '/vagrant/local-config-db.php';
-	require_once '/vagrant/local-config-extensions.php';
-	 // @codingStandardsIgnoreEnd
+	define( 'DB_NAME',     'wordpress' );
+	define( 'DB_USER',     'wordpress' );
+	define( 'DB_PASSWORD', 'vagrantpassword' );
+	define( 'DB_HOST',     'localhost' );
 
-	$table_prefix = $original_table_prefix;
+	defined( 'ABSPATH' ) or define( 'ABSPATH', '/chassis/wordpress/' );
+	defined( 'WP_CONTENT_DIR' ) or define( 'WP_CONTENT_DIR', '/chassis/content' );
+
+	require_once '/vagrant/local-config-extensions.php';
+	// @codingStandardsIgnoreEnd
+
 
 	// When Chassis is configured with subdomains for hosts, it will attempt to load
 	// a file via /vagrant/local-config-extensions.php that will register a filter

--- a/load.php
+++ b/load.php
@@ -7,11 +7,15 @@ use function Altis\register_module;
 
 // Load database configuration on Chassis installs.
 if ( file_exists( '/vagrant/local-config-db.php' ) ) {
+	$original_table_prefix = $table_prefix ?? 'wp_';
+
 	 // @codingStandardsIgnoreStart
 	define( 'HM_ENV_ARCHITECTURE', 'chassis' );
 	require_once '/vagrant/local-config-db.php';
 	require_once '/vagrant/local-config-extensions.php';
 	 // @codingStandardsIgnoreEnd
+
+	$table_prefix = $original_table_prefix;
 
 	// When Chassis is configured with subdomains for hosts, it will attempt to load
 	// a file via /vagrant/local-config-extensions.php that will register a filter

--- a/load.php
+++ b/load.php
@@ -17,9 +17,12 @@ if ( file_exists( '/vagrant/local-config-extensions.php' ) ) {
 	defined( 'ABSPATH' ) or define( 'ABSPATH', '/chassis/wordpress/' );
 	defined( 'WP_CONTENT_DIR' ) or define( 'WP_CONTENT_DIR', '/chassis/content' );
 
-	require_once '/vagrant/local-config-extensions.php';
-	// @codingStandardsIgnoreEnd
+	if ( empty( $_SERVER['HTTP_HOST'] ) ) {
+		$_SERVER['HTTP_HOST'] = 'altis.local';
+	}
 
+	require_once '/vagrant/local-config-extensions.php';
+	 // @codingStandardsIgnoreEnd
 
 	// When Chassis is configured with subdomains for hosts, it will attempt to load
 	// a file via /vagrant/local-config-extensions.php that will register a filter


### PR DESCRIPTION
The exec command allows running arbitrary commands on the server such as `vendor/bin/phpunit`.

The changes to load.php prevent errors caused during PHPUnit bootstrapping caused by defining multisite constants too early.

Would be good to get some extra scrutiny here.