### PR TITLE
Fix merging into non existent key

### DIFF
--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -490,7 +490,7 @@ EOT
 			if ( is_string( $key ) ) {
 				if ( is_array( $value ) ) {
 					// Recursively merge arrays.
-					$merged[ $key ] = $this->merge_config( $merged[ $key ], $value );
+					$merged[ $key ] = $this->merge_config( $merged[ $key ] ?? [], $value );
 				} else {
 					// Overwrite scalar values directly.
 					$merged[ $key ] = $value;


### PR DESCRIPTION
If the target property did not exist in the array being merged to the recursive merge would fail.

Reported by @kucrut

Fixes #67 