### PR TITLE
Declares the minimum PHP version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
 	],
 	"type": "composer-plugin",
 	"require": {
+		"php": ">=7.0",
 		"composer-plugin-api": "^1.1",
 		"symfony/yaml": "^4.2"
 	},


### PR DESCRIPTION
Closes #72 and prevents package installation with an incompatible PHP version