### PR TITLE
Update Elasticsearch repo version

### DIFF
--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -464,7 +464,7 @@ EOT
 				'humanmade/platform_chassis_extension',
 			],
 			'elasticsearch' => [
-				'repo_version' => '6.x',
+				'repo_version' => '6',
 				'version' => '6.3.1',
 				'plugins' => [
 					'analysis-icu',


### PR DESCRIPTION
After https://github.com/Chassis/Chassis_Elasticsearch/pull/19 the repo version should be supplied as a single number rather than `6.x`. The upstream change is backwards compatible however so this doesn't need to be backported.