### PR TITLE
Use standard | for command alternatives

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,9 +58,9 @@ A number of convenience commands are available:
 * `composer chassis status` - Displays the status of the virtual machine.
 * `composer chassis secure` - Installs the generated SSL certificate to your trusted certificate store.
 * `composer chassis destroy` - Destroys the virtual machine.
-* `composer chassis ssh\shell` - Logs in to the virtual machine.
+* `composer chassis ssh|shell` - Logs in to the virtual machine.
 * `composer chassis exec -- <command>` - Run a command on the virtual machine.
-* `composer chassis restart\reload` - Restart the virtual machine.
+* `composer chassis restart|reload` - Restart the virtual machine.
 * `composer chassis provision` - Updates the `config.local.yaml` file and re-provisions the machine.
 * `composer chassis upgrade` - Upgrade Chassis and the extensions. _Note this will remove any extensions added manually._
 


### PR DESCRIPTION
Previous documentation used `\` which is confusing, as it's a path separator on Windows, and looks like part of the command. `|` is fairly standard for alternations (provided there's no spaces, otherwise it looks like a pipe).

Alternatively, we could split this back to two commands.