### PR TITLE
Support "up" and "halt" as command aliases

### DIFF
--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -87,6 +87,7 @@ EOT
 			case 'init':
 				return $this->init( $input, $output );
 
+			case 'up':
 			case 'start':
 				return $this->start( $input, $output );
 
@@ -97,6 +98,7 @@ EOT
 			case 'reload':
 				return $this->restart( $input, $output );
 
+			case 'halt':
 			case 'stop':
 				return $this->stop( $input, $output );
 


### PR DESCRIPTION
I _believe_ this will resolve the issue John describes in #82, but I'm not certain how best to test it. I do think that his proposed enhancement is worth supporting, so if this doesn't do the trick please let me know the appropriate path and I'll do that instead :slightly_smiling_face: 

Muscle memory is a strong force, and not having these commands work as expected is a consistent pain point when using local-chassis. This will cause the API surface to deviate a bit from local-server, but as the underlying technology is different that seems appropriate.