### PR TITLE
Fix linter errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 	},
 	"autoload": {
 		"files": [
-			"inc/namespace.php"
+			"inc/namespace.php",
+			"wp-config.php"
 		],
 		"classmap": [
 			"inc/"

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Altis Local Chassis Composer Command.
+ *
+ * @package altis-local-chassis
+ */
 
 namespace Altis\Local_Chassis;
 
@@ -75,11 +80,12 @@ EOT
 	}
 
 	/**
-	 * Wrapper command to dispatch subcommands
+	 * Wrapper command to dispatch subcommands.
 	 *
-	 * @param InputInterface $input
-	 * @param OutputInterface $output
-	 * @return int Status code to return
+	 * @param InputInterface $input Command input.
+	 * @param OutputInterface $output Command output.
+	 * @return int Status code to return.
+	 * @throws CommandNotFoundException Thrown if the specified subcommand is not found.
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ) {
 		$command = $input->getArgument( 'subcommand' );
@@ -128,9 +134,9 @@ EOT
 	/**
 	 * Command to initialize a Chassis install.
 	 *
-	 * @param InputInterface $input
-	 * @param OutputInterface $output
-	 * @return int Status code to return
+	 * @param InputInterface $input Command input.
+	 * @param OutputInterface $output Command output.
+	 * @return int Status code to return.
 	 */
 	protected function init( InputInterface $input, OutputInterface $output ) {
 		$questioner = $this->getHelper( 'question' );
@@ -196,8 +202,9 @@ EOT
 	/**
 	 * Run a command in the Chassis directory.
 	 *
-	 * @param string $command Command to execute
-	 * @return int Status returned from the command
+	 * @param string $command Command to execute.
+	 * @return int Status returned from the command.
+	 * @throws Exception If chassis has not yet been downloaded.
 	 */
 	protected function run_command( $command ) {
 		$cwd = getcwd();
@@ -215,6 +222,9 @@ EOT
 
 	/**
 	 * Command to start the virtual machine
+	 *
+	 * @param InputInterface $input Command input.
+	 * @param OutputInterface $output Command output.
 	 */
 	protected function start( InputInterface $input, OutputInterface $output ) {
 		$hosts = $this->get_project_hosts();
@@ -231,21 +241,30 @@ EOT
 	}
 
 	/**
-	 * Command to check the virtual machine's status
+	 * Command to check the virtual machine's status.
+	 *
+	 * @param InputInterface $input Command input.
+	 * @param OutputInterface $output Command output.
 	 */
 	protected function status( InputInterface $input, OutputInterface $output ) {
 		return $this->run_command( 'vagrant status' );
 	}
 
 	/**
-	 * Command to restart the virtual machine
+	 * Command to restart the virtual machine.
+	 *
+	 * @param InputInterface $input Command input.
+	 * @param OutputInterface $output Command output.
 	 */
 	protected function restart( InputInterface $input, OutputInterface $output ) {
 		return $this->run_command( 'vagrant reload' );
 	}
 
 	/**
-	 * Command to stop the virtual machine
+	 * Command to stop the virtual machine.
+	 *
+	 * @param InputInterface $input Command input.
+	 * @param OutputInterface $output Command output.
 	 */
 	protected function stop( InputInterface $input, OutputInterface $output ) {
 		return $this->run_command( 'vagrant halt' );
@@ -253,6 +272,9 @@ EOT
 
 	/**
 	 * Command to install the generated HTTPS cert.
+	 *
+	 * @param InputInterface $input Command input.
+	 * @param OutputInterface $output Command output.
 	 */
 	protected function secure( InputInterface $input, OutputInterface $output ) {
 		$chassis_dir = $this->get_chassis_dir();
@@ -303,6 +325,9 @@ EOT
 
 	/**
 	 * Command to ssh in to the virtual machine.
+	 *
+	 * @param InputInterface $input Command input.
+	 * @param OutputInterface $output Command output.
 	 */
 	protected function shell( InputInterface $input, OutputInterface $output ) {
 		return $this->run_command( 'vagrant ssh' );
@@ -310,6 +335,9 @@ EOT
 
 	/**
 	 * Command to destroy the virtual machine.
+	 *
+	 * @param InputInterface $input Command input.
+	 * @param OutputInterface $output Command output.
 	 */
 	protected function destroy( InputInterface $input, OutputInterface $output ) {
 		return $this->run_command( 'vagrant destroy' );
@@ -317,6 +345,9 @@ EOT
 
 	/**
 	 * Command to pass a command in to the virtual machine.
+	 *
+	 * @param InputInterface $input Command input.
+	 * @param OutputInterface $output Command output.
 	 */
 	protected function exec( InputInterface $input, OutputInterface $output ) {
 		$command = implode( ' ', $input->getArgument( 'options' ) );
@@ -344,8 +375,8 @@ EOT
 	/**
 	 * Command to upgrade chassis and re provision the VM.
 	 *
-	 * @param InputInterface $input
-	 * @param OutputInterface $output
+	 * @param InputInterface $input Command input.
+	 * @param OutputInterface $output Command output.
 	 * @return int Status code to return.
 	 */
 	protected function upgrade( InputInterface $input, OutputInterface $output ) {
@@ -408,7 +439,7 @@ EOT
 	 * @return array
 	 */
 	protected function get_config() : array {
-		// @codingStandardsIgnoreLine
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$json = file_get_contents( $this->get_root_dir() . DIRECTORY_SEPARATOR . 'composer.json' );
 		$composer_json = json_decode( $json, true );
 

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -2,7 +2,7 @@
 /**
  * Altis Local Chassis Composer Command.
  *
- * @package altis-local-chassis
+ * @package altis/local-chassis
  */
 
 namespace Altis\Local_Chassis;

--- a/inc/class-commandprovider.php
+++ b/inc/class-commandprovider.php
@@ -2,7 +2,7 @@
 /**
  * Altis Local Chassis Command Provider.
  *
- * @package altis-local-chassis
+ * @package altis/local-chassis
  */
 
 namespace Altis\Local_Chassis;
@@ -12,7 +12,7 @@ use Composer\Plugin\Capability\CommandProvider as CommandProviderCapability;
 /**
  * Altis Local Chassis Command Provider.
  *
- * @package altis-local-chassis
+ * @package altis/local-chassis
  */
 class CommandProvider implements CommandProviderCapability {
 	/**

--- a/inc/class-commandprovider.php
+++ b/inc/class-commandprovider.php
@@ -1,10 +1,25 @@
 <?php
+/**
+ * Altis Local Chassis Command Provider.
+ *
+ * @package altis-local-chassis
+ */
 
 namespace Altis\Local_Chassis;
 
 use Composer\Plugin\Capability\CommandProvider as CommandProviderCapability;
 
+/**
+ * Altis Local Chassis Command Provider.
+ *
+ * @package altis-local-chassis
+ */
 class CommandProvider implements CommandProviderCapability {
+	/**
+	 * Return available commands.
+	 *
+	 * @return array
+	 */
 	public function getCommands() {
 		return [
 			new Command(),

--- a/inc/class-composerplugin.php
+++ b/inc/class-composerplugin.php
@@ -2,7 +2,7 @@
 /**
  * Altis Local Chassis Composer Plugin.
  *
- * @package altis-local-chassis
+ * @package altis/local-chassis
  */
 
 namespace Altis\Local_Chassis;
@@ -15,7 +15,7 @@ use Composer\Plugin\PluginInterface;
 /**
  * Altis Local Chassis Composer Plugin.
  *
- * @package altis-local-chassis
+ * @package altis/local-chassis
  */
 class ComposerPlugin implements PluginInterface, Capable {
 	/**

--- a/inc/class-composerplugin.php
+++ b/inc/class-composerplugin.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Altis Local Chassis Composer Plugin.
+ *
+ * @package altis-local-chassis
+ */
 
 namespace Altis\Local_Chassis;
 
@@ -7,10 +12,27 @@ use Composer\IO\IOInterface;
 use Composer\Plugin\Capable;
 use Composer\Plugin\PluginInterface;
 
+/**
+ * Altis Local Chassis Composer Plugin.
+ *
+ * @package altis-local-chassis
+ */
 class ComposerPlugin implements PluginInterface, Capable {
+	/**
+	 * Plugin activation callback.
+	 *
+	 * @param Composer $composer Composer object.
+	 * @param IOInterface $io Composer disk interface.
+	 * @return void
+	 */
 	public function activate( Composer $composer, IOInterface $io ) {
 	}
 
+	/**
+	 * Return plugin capabilities.
+	 *
+	 * @return array
+	 */
 	public function getCapabilities() {
 		return [
 			'Composer\\Plugin\\Capability\\CommandProvider' => __NAMESPACE__ . '\\CommandProvider',

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -20,6 +20,7 @@ function set_file_path_map( array $map ) : array {
 	if ( ! file_exists( '/etc/chassis-constants' ) ) {
 		return $map;
 	}
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 	$json_string = file_get_contents( '/etc/chassis-constants' );
 	$data = json_decode( $json_string, true );
 	if ( empty( $data ) ) {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -2,7 +2,7 @@
 /**
  * Altis Local Chassis.
  *
- * @package altis-local-chassis
+ * @package altis/local-chassis
  */
 
 namespace Altis\Local_Chassis;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Altis Local Chassis.
+ *
+ * @package altis-local-chassis
+ */
 
 namespace Altis\Local_Chassis;
 
@@ -13,7 +18,7 @@ function bootstrap() {
 /**
  * Enables Query Monitor to map paths to their original values on the host.
  *
- * @param array $map Map of guest path => host path
+ * @param array $map Map of guest path => host path.
  * @return array Adjusted mapping of folders
  */
 function set_file_path_map( array $map ) : array {

--- a/load.php
+++ b/load.php
@@ -2,7 +2,7 @@
 /**
  * Altis Local Chassis Module.
  *
- * @package altis-local-chassis
+ * @package altis/local-chassis
  */
 
 namespace Altis\Local_Chassis; // phpcs:ignore

--- a/load.php
+++ b/load.php
@@ -1,16 +1,20 @@
 <?php
+/**
+ * Altis Local Chassis Module.
+ *
+ * @package altis-local-chassis
+ */
 
-namespace Altis\Local_Chassis;
+namespace Altis\Local_Chassis; // phpcs:ignore
 
-use function Altis\get_environment_architecture;
-use function Altis\register_module;
+use Altis;
 
 add_action( 'altis.modules.init', function () {
 	$default_settings = [
-		'enabled' => get_environment_architecture() === 'chassis',
+		'enabled' => Altis\get_environment_architecture() === 'chassis',
 	];
 
-	register_module(
+	Altis\register_module(
 		'local-chassis',
 		__DIR__,
 		'Local Chassis',

--- a/load.php
+++ b/load.php
@@ -1,14 +1,9 @@
 <?php
 
-namespace Altis\Local_Chassis;  // @codingStandardsIgnoreLine
+namespace Altis\Local_Chassis;
 
 use function Altis\get_environment_architecture;
 use function Altis\register_module;
-
-// Set the architecture constant when on the VM.
-if ( file_exists( '/vagrant/local-config-db.php' ) ) {
-	define( 'HM_ENV_ARCHITECTURE', 'chassis' );
-}
 
 add_action( 'altis.modules.init', function () {
 	$default_settings = [

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,0 +1,6 @@
+<?php
+
+// Set the architecture constant when on the VM.
+if ( file_exists( '/vagrant/local-config-db.php' ) ) {
+	define( 'HM_ENV_ARCHITECTURE', 'chassis' ); // phpcs:ignore
+}

--- a/wp-config.php
+++ b/wp-config.php
@@ -2,7 +2,7 @@
 /**
  * Set the architecture constant when on the VM.
  *
- * @package altis-local-chassis
+ * @package altis/local-chassis
  */
 
 if ( file_exists( '/vagrant/local-config-db.php' ) ) {

--- a/wp-config.php
+++ b/wp-config.php
@@ -1,6 +1,10 @@
 <?php
+/**
+ * Set the architecture constant when on the VM.
+ *
+ * @package altis-local-chassis
+ */
 
-// Set the architecture constant when on the VM.
 if ( file_exists( '/vagrant/local-config-db.php' ) ) {
-	define( 'HM_ENV_ARCHITECTURE', 'chassis' ); // phpcs:ignore
+	define( 'HM_ENV_ARCHITECTURE', 'chassis' );
 }


### PR DESCRIPTION
This moves the architecture constant to a separate file to avoid the PSR1.Files.SideEffects.FoundWithSymbols sniff error