### PR TITLE
Avoid PHP warning if 'muplugins_loaded' key is missing

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -68,7 +68,7 @@ function load_chassis() {
 	//
 	// As a workaround, we remove the "direct" added hook via the PHP global, and just call
 	// add_action on the function that was registered.
-	if ( is_array( $GLOBALS['wp_filter']['muplugins_loaded'] ) && isset( $GLOBALS['wp_filter']['muplugins_loaded'][10]['chassis-hosts'] ) ) {
+	if ( isset( $GLOBALS['wp_filter']['muplugins_loaded'][10]['chassis-hosts']['function'] ) ) {
 		$function = $GLOBALS['wp_filter']['muplugins_loaded'][10]['chassis-hosts']['function'];
 		unset( $GLOBALS['wp_filter']['muplugins_loaded'] );
 		add_action( 'muplugins_loaded', $function );


### PR DESCRIPTION
I've observed one of our HM Altis sites filling up its logs with warnings around "Undefined index: muplugins_loaded" when evaluating this check. The `isset()` check on its own is sufficient to deeply check the object to see whether we are in the state this conditional is meant to address, and removing the `is_array` sidesteps triggering a warning if the filters are not yet set up.