### PR TITLE
Provide default Database credentials

### DIFF
--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -517,7 +517,7 @@ EOT
 				'user' => 'wordpress',
 				'password' => 'vagrantpassword',
 				'prefix' => 'wp_',
-			]
+			],
 		];
 
 		// Merge config from composer.json.

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -512,6 +512,12 @@ EOT
 					'mapper-murmur3',
 				],
 			],
+			'database' => [
+				'name' => 'wordpress',
+				'user' => 'wordpress',
+				'password' => 'vagrantpassword',
+				'prefix' => 'wp_',
+			]
 		];
 
 		// Merge config from composer.json.


### PR DESCRIPTION
Due to a bug when upgrading Altis v4, during Chassis provisioning, the database credentials were missing and Chassis was complanining about a missing DB Prefix.