### PR TITLE
Fix the upgrade command on Linux hosts.

### DIFF
--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -400,10 +400,10 @@ EOT
 
 		// Clean extensions directory.
 		$os = php_uname();
-		if ( strpos( $os, 'Darwin' ) !== false ) {
-			$failed = $this->run_command( 'rm -rf extensions' );
-		} elseif ( strpos( $os, 'Windows' ) !== false ) {
+		if ( strpos( $os, 'Windows' ) !== false ) {
 			$failed = $this->run_command( 'rmdir extensions' );
+		} else {
+			$failed = $this->run_command( 'rm -rf extensions' );
 		}
 		if ( $failed ) {
 			$output->writeln( '<error>Unable to clean existing extensions.</>' );


### PR DESCRIPTION
A small change for cleaning up the extensions directory on Linux and other Unix-like hosts. The only OS where `rm -rf` won't work is Windows.