### PR TITLE
Fix v8js and mcrypt settings for PHP 7.4

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,8 @@ From Altis v7 onwards the minimum required version of PHP is 7.4. If needed you 
 }
 ```
 
+Please note that not all Chassis extensions are guaranteed to work a version of PHP other than the default for your current version of Altis.
+
 
 ## Setup
 

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -520,6 +520,9 @@ EOT
 				'password' => 'vagrantpassword',
 				'prefix' => 'wp_',
 			],
+			'libv8' => '7.5',
+			'v8js' => '2.1.2',
+			'mcrypt' => '1.0.4',
 		];
 
 		// Merge config from composer.json.


### PR DESCRIPTION
Provisioning was failing with v8js 2.1.1 and mcrypt 1.0.2 so it had a knock on effect meaning the site could not be provisioned successfully or the dev tools phpunit command run etc...

Fixes #130