### PR TITLE
Fixing link to Chassis troubleshooting guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -137,4 +137,4 @@ Because the Firefox browser uses its own certificate store you will either need 
 
 ## Troubleshooting
 
-Consult the [Chassis Troubleshooting guide](https://docs.chassis.io/en/latest/reference/#troubleshooting)
+Consult the [Chassis Troubleshooting guide](https://docs.chassis.io/en/main/reference/#troubleshooting)


### PR DESCRIPTION
The URL with `/latest/` is 404'ing so changing this to the `main` branch.