### PR TITLE
Don't always set the `machine_name`

### DIFF
--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -537,8 +537,10 @@ EOT
 		// Set hosts.
 		$config['hosts'] = $this->get_project_hosts();
 
-		// Set the machine name.
-		$config['machine_name'] = $config['hosts'][0];
+		// Maybe set the machine name.
+		if ( 'default' === $config['machine_name'] ) {
+			$config['machine_name'] = $config['hosts'][0];
+		}
 
 		// Remove the enabled setting.
 		unset( $config['enabled'] );

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -537,8 +537,8 @@ EOT
 		// Set hosts.
 		$config['hosts'] = $this->get_project_hosts();
 
-		// Maybe set the machine name.
-		if ( 'default' === $config['machine_name'] ) {
+		// Set the machine name if not manually configured.
+		if ( ! isset( $config['machine_name'] ) ) {
 			$config['machine_name'] = $config['hosts'][0];
 		}
 


### PR DESCRIPTION
I wanted to set the `machine_name` in my `composer.json` file however I couldn't as it's set to `$config['hosts'][0]`. I understand the logic for this would be so that you don't have duplicate machines named `default` from the upstream Chassis default. However, I'd like to have the option to set it so this should take care of that.