### PR TITLE
Add a troubleshooting note for expired certificate error

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -161,4 +161,15 @@ Because the Firefox browser uses its own certificate store you will either need 
 
 ## Troubleshooting
 
-Consult the [Chassis Troubleshooting guide](https://docs.chassis.io/en/latest/reference/#troubleshooting)
+### Certificate verification failed error during init
+
+If you get `Certificate verification failed` error during provision of the chassis environment, you'll need to install `ca-certificates` packages within the chassis box, then reprovision the environment again, using the following commands:
+
+```
+cd chassis
+vagrant ssh -c 'sudo apt-get install ca-certificates`
+cd -
+composer chassis init
+```
+
+Consult the [Chassis Troubleshooting guide](https://docs.chassis.io/en/latest/reference/#troubleshooting) for further troubleshooting guides.

--- a/docs/README.md
+++ b/docs/README.md
@@ -169,7 +169,7 @@ If you get `Certificate verification failed` error during provision of the chass
 cd chassis
 vagrant ssh -c 'sudo apt-get install ca-certificates`
 cd -
-composer chassis init
+composer chassis provision
 ```
 
 Consult the [Chassis Troubleshooting guide](https://docs.chassis.io/en/latest/reference/#troubleshooting) for further troubleshooting guides.

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -145,46 +145,40 @@ EOT
 
 		// Check we're not overwriting it.
 		$chassis_dir = $this->get_chassis_dir();
-
 		if ( file_exists( $chassis_dir ) ) {
 			$output->writeln( sprintf( '<warning>The Chassis directory already exists at %s</warning>', $chassis_dir ) );
+			return 1;
+		}
 
-			// Ask the user if they'd like to reprovision the existing install.
-			$question = new ConfirmationQuestion( '<warning>Reprovision the existing install? [Y/n]</warning>', true );
-			if ( ! $questioner->ask( $input, $output, $question ) ) {
-				return 1;
-			}
-		} else {
-			$output->writeln( sprintf( '<info>Installing Chassis into %s</info>', $chassis_dir ) );
+		$output->writeln( sprintf( '<info>Installing Chassis into %s</info>', $chassis_dir ) );
 
-			// First, clone down Chassis.
-			$command = sprintf(
-				'git clone --recursive %s %s',
-				escapeshellarg( REPO ),
-				escapeshellarg( $chassis_dir )
-			);
-			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_passthru
-			passthru( $command, $status );
-			if ( $status !== 0 ) {
-				$output->writeln( '<error>Could not clone Chassis successfully</error>' );
-				return $status;
-			}
+		// First, clone down Chassis.
+		$command = sprintf(
+			'git clone --recursive %s %s',
+			escapeshellarg( REPO ),
+			escapeshellarg( $chassis_dir )
+		);
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_passthru
+		passthru( $command, $status );
+		if ( $status !== 0 ) {
+			$output->writeln( '<error>Could not clone Chassis successfully</error>' );
+			return $status;
+		}
 
-			// Create the default config file.
-			$success = $this->write_config_file();
-			if ( ! $success ) {
-				$output->writeln( '<error>Could not write Chassis config</error>' );
-				return 1;
-			}
+		// Create the default config file.
+		$success = $this->write_config_file();
+		if ( ! $success ) {
+			$output->writeln( '<error>Could not write Chassis config</error>' );
+			return 1;
+		}
 
-			$output->writeln( '' );
-			$output->writeln( '<info>Chassis downloaded and configured.</info>' );
+		$output->writeln( '' );
+		$output->writeln( '<info>Chassis downloaded and configured.</info>' );
 
-			// And run the initial setup, if the user wants to.
-			$question = new ConfirmationQuestion( 'Launch and install virtual machine? [Y/n] ', true );
-			if ( ! $questioner->ask( $input, $output, $question ) ) {
-				return;
-			}
+		// And run the initial setup, if the user wants to.
+		$question = new ConfirmationQuestion( 'Launch and install virtual machine? [Y/n] ', true );
+		if ( ! $questioner->ask( $input, $output, $question ) ) {
+			return;
 		}
 
 		$status = $this->start( $input, $output );
@@ -238,7 +232,7 @@ EOT
 	 */
 	protected function start( InputInterface $input, OutputInterface $output ) {
 		$hosts = $this->get_project_hosts();
-		$status = $this->run_command( 'vagrant up --provision' );
+		$status = $this->run_command( 'vagrant up' );
 
 		if ( $status === 0 ) {
 			$output->writeln( '<info>Start up complete!</>' );

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -145,40 +145,46 @@ EOT
 
 		// Check we're not overwriting it.
 		$chassis_dir = $this->get_chassis_dir();
+
 		if ( file_exists( $chassis_dir ) ) {
 			$output->writeln( sprintf( '<warning>The Chassis directory already exists at %s</warning>', $chassis_dir ) );
-			return 1;
-		}
 
-		$output->writeln( sprintf( '<info>Installing Chassis into %s</info>', $chassis_dir ) );
+			// Ask the user if they'd like to reprovision the existing install.
+			$question = new ConfirmationQuestion( '<warning>Reprovision the existing install? [Y/n]</warning>', true );
+			if ( ! $questioner->ask( $input, $output, $question ) ) {
+				return 1;
+			}
+		} else {
+			$output->writeln( sprintf( '<info>Installing Chassis into %s</info>', $chassis_dir ) );
 
-		// First, clone down Chassis.
-		$command = sprintf(
-			'git clone --recursive %s %s',
-			escapeshellarg( REPO ),
-			escapeshellarg( $chassis_dir )
-		);
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_passthru
-		passthru( $command, $status );
-		if ( $status !== 0 ) {
-			$output->writeln( '<error>Could not clone Chassis successfully</error>' );
-			return $status;
-		}
+			// First, clone down Chassis.
+			$command = sprintf(
+				'git clone --recursive %s %s',
+				escapeshellarg( REPO ),
+				escapeshellarg( $chassis_dir )
+			);
+			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_passthru
+			passthru( $command, $status );
+			if ( $status !== 0 ) {
+				$output->writeln( '<error>Could not clone Chassis successfully</error>' );
+				return $status;
+			}
 
-		// Create the default config file.
-		$success = $this->write_config_file();
-		if ( ! $success ) {
-			$output->writeln( '<error>Could not write Chassis config</error>' );
-			return 1;
-		}
+			// Create the default config file.
+			$success = $this->write_config_file();
+			if ( ! $success ) {
+				$output->writeln( '<error>Could not write Chassis config</error>' );
+				return 1;
+			}
 
-		$output->writeln( '' );
-		$output->writeln( '<info>Chassis downloaded and configured.</info>' );
+			$output->writeln( '' );
+			$output->writeln( '<info>Chassis downloaded and configured.</info>' );
 
-		// And run the initial setup, if the user wants to.
-		$question = new ConfirmationQuestion( 'Launch and install virtual machine? [Y/n] ', true );
-		if ( ! $questioner->ask( $input, $output, $question ) ) {
-			return;
+			// And run the initial setup, if the user wants to.
+			$question = new ConfirmationQuestion( 'Launch and install virtual machine? [Y/n] ', true );
+			if ( ! $questioner->ask( $input, $output, $question ) ) {
+				return;
+			}
 		}
 
 		$status = $this->start( $input, $output );

--- a/inc/class-command.php
+++ b/inc/class-command.php
@@ -238,7 +238,7 @@ EOT
 	 */
 	protected function start( InputInterface $input, OutputInterface $output ) {
 		$hosts = $this->get_project_hosts();
-		$status = $this->run_command( 'vagrant up' );
+		$status = $this->run_command( 'vagrant up --provision' );
 
 		if ( $status === 0 ) {
 			$output->writeln( '<info>Start up complete!</>' );


### PR DESCRIPTION
- ~Allow reinitiation of chassis on failure~
- Add a troubleshooting note for expired certificate error

This helps with certificate expiry issues, eg:

`Certificate verification failed: The certificate is NOT trusted. The certificate chain uses expired certificate.  Could not handshake: Error in the certificate verification.`
